### PR TITLE
feat(rearrangement): Allow overriding rearrangement logic

### DIFF
--- a/src/PanelistProvider.tsx
+++ b/src/PanelistProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState } from "react";
-import type { PanelCoordinate, PanelId } from "./types";
+import type { PanelCoordinate, PanelId, RearrangementFunction } from "./types";
 import { usePanelist } from "./usePanelist";
 
 type PanelistState = ReturnType<typeof usePanelist>;
@@ -27,9 +27,20 @@ interface PanelistProviderProps {
   columnCount: number;
   gap: number;
   children: React.ReactNode;
+  /**
+   * Optional custom rearrangement function to override default collision resolution logic
+   * If provided, this function will be called instead of the default rearrangePanels
+   */
+  rearrangement?: RearrangementFunction;
 }
 
-export function PanelistProvider({ panels: initialPanels, columnCount, gap, children }: PanelistProviderProps) {
+export function PanelistProvider({
+  panels: initialPanels,
+  columnCount,
+  gap,
+  children,
+  rearrangement,
+}: PanelistProviderProps) {
   const [baseSize, setBaseSize] = useState<number | null>(null);
 
   const { panels, addPanel, removePanel, exportState, ghostPanelRef } = usePanelist({
@@ -37,6 +48,7 @@ export function PanelistProvider({ panels: initialPanels, columnCount, gap, chil
     columnCount,
     baseSize: baseSize || 256,
     gap,
+    rearrangement,
   });
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { rearrangePanels } from "./helpers/rearrangement";
 export { PanelistProvider, usePanelistControls, usePanelistState } from "./PanelistProvider";
 export { PanelistRenderer } from "./PanelistRenderer";
-export type { PanelCoordinate, PanelId } from "./types";
+export type { PanelCoordinate, PanelId, RearrangementFunction } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,3 +15,14 @@ export interface PanelCoordinate {
   w: number;
   h: number;
 }
+
+/**
+ * Custom rearrangement function type
+ * Takes a moved/resized panel, all panels, and column count
+ * Returns the new panel arrangement after resolving collisions
+ */
+export type RearrangementFunction = (
+  movingPanel: PanelCoordinate,
+  allPanels: PanelCoordinate[],
+  columnCount: number
+) => PanelCoordinate[];

--- a/src/usePanelist.ts
+++ b/src/usePanelist.ts
@@ -9,13 +9,14 @@ import {
   rearrangePanels,
 } from "./helpers";
 import { findNewPositionToAddPanel } from "./helpers/rearrangement";
-import type { PanelCoordinate } from "./types";
+import type { PanelCoordinate, RearrangementFunction } from "./types";
 
 interface PanelistOptions {
   panels: PanelCoordinate[];
   columnCount: number;
   baseSize: number;
   gap: number;
+  rearrangement?: RearrangementFunction;
 }
 
 interface PanelistState {
@@ -35,7 +36,7 @@ interface InternalPanelState {
 const ANIMATION_DURATION = 300;
 type TimeoutId = ReturnType<typeof setTimeout>;
 
-export function usePanelist({ panels, columnCount, baseSize, gap }: PanelistOptions) {
+export function usePanelist({ panels, columnCount, baseSize, gap, rearrangement }: PanelistOptions) {
   const [state, setState] = useState<PanelistState>({
     panels,
   });
@@ -93,7 +94,9 @@ export function usePanelist({ panels, columnCount, baseSize, gap }: PanelistOpti
   // Callback to update panels and trigger animations
   const updatePanelsWithAnimation = useCallback(
     (updatedPanel: PanelCoordinate, currentPanels: PanelCoordinate[]) => {
-      const nextPanels = rearrangePanels(updatedPanel, currentPanels, columnCount);
+      // Use custom rearrangement function if provided, otherwise use default
+      const rearrange = rearrangement || rearrangePanels;
+      const nextPanels = rearrange(updatedPanel, currentPanels, columnCount);
 
       // Detect which panels have been rearranged
       internalState.animatingPanels = detectAnimatingPanels({
@@ -114,7 +117,7 @@ export function usePanelist({ panels, columnCount, baseSize, gap }: PanelistOpti
       }, ANIMATION_DURATION);
       animationTimeoutsRef.current.add(timeoutId);
     },
-    [columnCount, internalState]
+    [columnCount, internalState, rearrangement]
   );
 
   // Create drag handler for a specific panel


### PR DESCRIPTION
## Summary

This PR adds the ability to override the default rearrangement logic with a custom implementation, providing flexibility for users who need different collision resolution strategies.

## Changes

### Added

#### New Type: `RearrangementFunction`
```typescript
export type RearrangementFunction = (
  movingPanel: PanelCoordinate,
  allPanels: PanelCoordinate[],
  columnCount: number
) => PanelCoordinate[];
```

A custom function type that takes:
- `movingPanel`: The panel being moved or resized
- `allPanels`: All panels in the grid
- `columnCount`: Number of columns in the grid

Returns the new panel arrangement after resolving collisions.

#### New Prop: `rearrangement`
Added optional `rearrangement` prop to `PanelistProvider`:

```typescript
<PanelistProvider
  panels={panels}
  columnCount={6}
  gap={8}
  rearrangement={customRearrangementFn}  // Optional custom function
>
  <PanelistRenderer itemRenderer={PanelContent} />
</PanelistProvider>
```

#### Documentation
Added comprehensive documentation to README.md including:
- Feature description
- Advanced Usage section with three examples
- Updated API documentation
- Type definitions
- Exported functions section

### Exported

- ✅ `RearrangementFunction` type
- ✅ `rearrangePanels` function (default implementation)

## Usage

### Using Default Rearrangement
```typescript
// No need to specify anything - default behavior
<PanelistProvider panels={panels} columnCount={6} gap={8}>
  <PanelistRenderer itemRenderer={PanelContent} />
</PanelistProvider>
```

### Using Custom Rearrangement

```typescript
import { PanelistProvider, rearrangePanels } from 'panelist';
import type { RearrangementFunction, PanelCoordinate } from 'panelist';

// Example: Custom rearrangement that prevents vertical movement
const customRearrange: RearrangementFunction = (
  movingPanel,
  allPanels,
  columnCount
) => {
  // Your custom collision resolution logic here
  // For example: only push panels horizontally, never vertically

  // You can also wrap the default function
  const result = rearrangePanels(movingPanel, allPanels, columnCount);

  // Apply custom modifications
  return result.map(panel => ({
    ...panel,
    // Custom logic...
  }));
};

// Use custom rearrangement
<PanelistProvider
  panels={panels}
  columnCount={6}
  gap={8}
  rearrangement={customRearrange}
>
  <PanelistRenderer itemRenderer={PanelContent} />
</PanelistProvider>
```

### Example: No Automatic Rearrangement
```typescript
import type { RearrangementFunction } from 'panelist';

// Simply return panels as-is, no automatic rearrangement
const noRearrangement: RearrangementFunction = (
  movingPanel,
  allPanels
) => {
  return allPanels.map(panel =>
    panel.id === movingPanel.id ? movingPanel : panel
  );
};

<PanelistProvider rearrangement={noRearrangement} {...otherProps}>
  {/* ... */}
</PanelistProvider>
```

### Example: Fixed Zones
```typescript
const zoneRearrangement: RearrangementFunction = (
  movingPanel,
  allPanels,
  columnCount
) => {
  // Define zones where panels can be placed
  const zones = {
    left: { xMin: 0, xMax: 2 },
    right: { xMin: 3, xMax: 5 }
  };

  // Use default rearrangement
  const result = rearrangePanels(movingPanel, allPanels, columnCount);

  // Constrain panels to their zones
  return result.map(panel => {
    const inLeftZone = panel.x < 3;
    const zone = inLeftZone ? zones.left : zones.right;

    return {
      ...panel,
      x: Math.max(zone.xMin, Math.min(panel.x, zone.xMax))
    };
  });
};
```

## Implementation Details

### Modified Files

1. **src/types.ts**
   - Added `RearrangementFunction` type definition

2. **src/PanelistProvider.tsx**
   - Added optional `rearrangement` prop to `PanelistProviderProps`
   - Passed `rearrangement` prop to `usePanelist` hook

3. **src/usePanelist.ts**
   - Added `rearrangement` to `PanelistOptions` interface
   - Updated `updatePanelsWithAnimation` to use custom function if provided
   - Falls back to default `rearrangePanels` if no custom function is specified

4. **src/index.ts**
   - Exported `RearrangementFunction` type
   - Exported `rearrangePanels` function for users to wrap/extend

5. **README.md**
   - Added "Customizable Rearrangement" to features list
   - Added "Advanced Usage" section with custom rearrangement examples
   - Updated API documentation with `rearrangement` prop
   - Added `RearrangementFunction` type to types section
   - Added "Exported Functions" section documenting `rearrangePanels`

### Backward Compatibility

✅ **Fully backward compatible** - The `rearrangement` prop is optional. If not provided, the default `rearrangePanels` function is used, maintaining existing behavior.

## Testing

```bash
# Type checking
$ yarn typecheck
✓ No type errors

# Linting
$ yarn lint
✓ All checks passed

# Build
$ yarn build
✓ Build successful (21.83 kB CJS, 21.34 kB ESM)
```

## Use Cases

This feature enables several advanced scenarios:

1. **Custom Collision Strategy**
   - Prevent vertical movement
   - Prefer specific directions
   - Implement grid zones with different behaviors

2. **Snap to Grid**
   - Force panels to specific positions
   - Implement magnetic alignment

3. **Layout Constraints**
   - Prevent panels from moving to certain areas
   - Implement fixed panel positions

4. **Performance Optimization**
   - Implement simpler/faster collision detection for specific use cases
   - Custom caching strategies

5. **No Automatic Rearrangement**
   - Manual panel placement only
   - Full control over panel positions

## API Documentation

### RearrangementFunction Type

```typescript
type RearrangementFunction = (
  movingPanel: PanelCoordinate,
  allPanels: PanelCoordinate[],
  columnCount: number
) => PanelCoordinate[];
```

**Parameters:**
- `movingPanel`: The panel that was just moved or resized
- `allPanels`: Array of all panels in their current positions
- `columnCount`: Number of columns in the grid

**Returns:**
- Array of all panels with their new positions after collision resolution

**Contract:**
- Must return the same number of panels as `allPanels`
- Must include all panel IDs from `allPanels`
- Should update `movingPanel` position in the returned array

### Exported Functions

#### `rearrangePanels(movingPanel, allPanels, columnCount)`

The default rearrangement function that:
- Detects collisions between panels
- Pushes colliding panels away horizontally first
- Falls back to vertical movement if horizontal space is unavailable
- Processes collisions in a queue to handle cascading movements

This function can be imported and wrapped/extended for custom behavior.

## Documentation

Complete documentation has been added to README.md including:
- ✅ Feature description in the features list
- ✅ Advanced Usage section with 3 practical examples
- ✅ Updated PanelistProvider API documentation
- ✅ Type definitions with full signature
- ✅ Exported functions documentation

## Breaking Changes

None - this is a purely additive feature.

Closes #18