### PR TITLE
docs: Remove accessibility claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A flexible and performant React grid layout library with drag-and-drop and resiz
 - 🎨 **Ghost Panel**: Visual preview of panel placement during drag/resize operations
 - ⚡ **Performance Optimized**: Direct DOM manipulation for high-frequency interactions
 - 🔧 **TypeScript**: Full type safety with comprehensive type definitions
-- ♿ **Accessible**: ARIA attributes and keyboard navigation support
 - 📦 **Tree-shakeable**: ESM and CommonJS builds available
 - 🎛️ **Customizable Rearrangement**: Override default collision resolution logic
 


### PR DESCRIPTION
## Summary

- Removed the misleading accessibility feature claim from README.md
- The library currently does not implement ARIA attributes or keyboard navigation support

## Details

During code review, it was discovered that the README.md claimed the following feature:

> ♿ **Accessible**: ARIA attributes and keyboard navigation support

However, investigation of the codebase revealed:
- No ARIA attributes (`role`, `aria-label`, `aria-grabbed`, etc.) are implemented
- No keyboard navigation support (`tabindex`, `onKeyDown` handlers, etc.)
- The library only supports mouse-based interactions

This PR removes the inaccurate feature claim to ensure the documentation accurately reflects the current implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)