### PR TITLE
refactor: Use local variables for isDragging and isResizing

### DIFF
--- a/src/usePanelGrid.ts
+++ b/src/usePanelGrid.ts
@@ -25,9 +25,7 @@ interface PanelGridState {
 
 interface InternalPanelState {
   activePanelId: number | string | null;
-  isDragging: boolean;
   draggableElements: Record<number | string, HTMLElement | null>;
-  isResizing: boolean;
   animatingPanels: Set<number | string>;
 }
 
@@ -43,9 +41,7 @@ export function usePanelGrid({ panels, columnCount, baseSize, gap, rearrangement
 
   const internalState = useRef<InternalPanelState>({
     activePanelId: null,
-    isDragging: false,
     draggableElements: {},
-    isResizing: false,
     animatingPanels: new Set(),
   }).current;
 
@@ -123,7 +119,7 @@ export function usePanelGrid({ panels, columnCount, baseSize, gap, rearrangement
       const draggingElement = internalState.draggableElements[panel.id];
       if (!draggingElement) return;
 
-      internalState.isDragging = true;
+      let isDragging = true;
       const initialX = e.clientX;
       const initialY = e.clientY;
       const offsetX = draggingElement.offsetLeft;
@@ -139,7 +135,7 @@ export function usePanelGrid({ panels, columnCount, baseSize, gap, rearrangement
       const mouseMoveListenerCtrl = new AbortController();
 
       const onMouseMove = (e: MouseEvent) => {
-        if (!internalState.isDragging) return;
+        if (!isDragging) return;
         if (!draggingElement) return;
 
         const currentX = e.clientX;
@@ -166,7 +162,7 @@ export function usePanelGrid({ panels, columnCount, baseSize, gap, rearrangement
       const onMouseUp = () => {
         if (!draggingElement) return;
 
-        internalState.isDragging = false;
+        isDragging = false;
         draggingElement.classList.remove("panelgrid-panel--dragging");
 
         hideGhostPanel();
@@ -222,7 +218,7 @@ export function usePanelGrid({ panels, columnCount, baseSize, gap, rearrangement
   const createResizeHandler = useCallback(
     (panel: PanelCoordinate) => (e: React.MouseEvent<HTMLSpanElement>) => {
       e.stopPropagation();
-      internalState.isResizing = true;
+      let isResizing = true;
       internalState.activePanelId = panel.id;
       const draggingElement = internalState.draggableElements[panel.id];
       if (!draggingElement) return;
@@ -242,7 +238,7 @@ export function usePanelGrid({ panels, columnCount, baseSize, gap, rearrangement
       const mouseUpController = new AbortController();
 
       const onMouseMove = (e: MouseEvent) => {
-        if (!internalState.isResizing) return;
+        if (!isResizing) return;
         if (!draggingElement) return;
 
         const deltaX = e.clientX - startX;
@@ -289,7 +285,7 @@ export function usePanelGrid({ panels, columnCount, baseSize, gap, rearrangement
 
         updatePanelsWithAnimation({ ...panel, w: nextGridW, h: nextGridH }, state.panels);
 
-        internalState.isResizing = false;
+        isResizing = false;
         internalState.activePanelId = null;
 
         mouseMoveController.abort();


### PR DESCRIPTION
## Summary
- Changed `isDragging` and `isResizing` from ref-managed state to local variables within their respective handlers
- Removed `isDragging` and `isResizing` from `InternalPanelState` interface

## Rationale
These flags are only used within the closure of their respective handlers (`createDragHandler` and `createResizeHandler`). Using local variables instead of ref-managed state:
- Makes the scope more explicit and clear
- Improves code readability
- Prevents potential state pollution in the global ref
- Each drag/resize operation now has its own independent local state

## Changes
- Removed `isDragging` and `isResizing` from `InternalPanelState` interface
- Removed initialization of these flags from `internalState` ref
- Changed to `let isDragging = true` in `createDragHandler`
- Changed to `let isResizing = true` in `createResizeHandler`

## Testing
- ✅ All tests pass (101 tests)
- ✅ TypeScript type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)