### PR TITLE
chore: Prepare package for npm publishing (v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-11-12
+
+### Added
+- Initial release of PanelGrid
+- Drag and drop panel repositioning with snap-to-grid behavior
+- Resizable panels with visual feedback
+- Ghost panel preview during drag/resize operations
+- Performance-optimized direct DOM manipulation for high-frequency interactions
+- TypeScript support with comprehensive type definitions
+- Customizable rearrangement logic via `rearrangement` prop
+- ESM and CommonJS build outputs
+- Separate CSS import (`panelgrid/styles.css`)
+- React 18 and React 19 support
+- Comprehensive test coverage (101 tests)
+- `PanelGridProvider` component for state management
+- `PanelGridRenderer` component for rendering grid layout
+- `usePanelGridControls` hook for panel manipulation (add, remove, export)
+- Animation system for smooth panel transitions
+- Collision detection and resolution
+- Grid boundary constraints

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tsuyoshi HARA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "includes": ["**", "!!**/dist"] },
+  "files": { "includes": ["**", "!!**/dist", "!!.claude", "!!package.json"] },
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "panelgrid",
-  "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "A flexible and performant React grid layout library with drag-and-drop and resize capabilities",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -15,6 +15,26 @@
     "./styles.css": "./dist/styles.css"
   },
   "files": ["dist"],
+  "keywords": [
+    "react",
+    "grid",
+    "layout",
+    "drag-and-drop",
+    "resize",
+    "dashboard",
+    "panel",
+    "typescript"
+  ],
+  "author": "Tsuyoshi HARA <chloe463+git@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chloe463/panelgrid.git"
+  },
+  "bugs": {
+    "url": "https://github.com/chloe463/panelgrid/issues"
+  },
+  "homepage": "https://github.com/chloe463/panelgrid#readme",
   "scripts": {
     "prepare": "husky",
     "dev": "vite",
@@ -25,7 +45,8 @@
     "format": "biome format --write .",
     "typecheck": "tsc -b --noEmit",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "prepublishOnly": "yarn test run && yarn typecheck && yarn lint && yarn build"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": ["biome check --write --no-errors-on-unmatched --files-ignore-unknown=true"]


### PR DESCRIPTION
## Summary
This PR prepares PanelGrid for its initial npm publication as version 0.1.0. All necessary metadata, legal files, and safety checks have been added.

## Changes

### New Files
- **LICENSE** - MIT License
- **CHANGELOG.md** - Initial changelog for v0.1.0 following Keep a Changelog format

### package.json Updates
- ✅ Removed `"private": true` to enable npm publishing
- ✅ Set version to `0.1.0`
- ✅ Added description: "A flexible and performant React grid layout library with drag-and-drop and resize capabilities"
- ✅ Added keywords for discoverability: react, grid, layout, drag-and-drop, resize, dashboard, panel, typescript
- ✅ Added author: Tsuyoshi HARA
- ✅ Added license: MIT
- ✅ Added repository URL
- ✅ Added bugs URL
- ✅ Added homepage URL
- ✅ Added `prepublishOnly` script for safety checks before publishing

### Configuration
- Updated biome.json to exclude package.json from formatting to preserve manual formatting

## Pre-Publish Verification ✅

- ✅ All tests pass (101/101)
- ✅ TypeScript type checking passes
- ✅ Linting passes
- ✅ Build succeeds with all outputs:
  - ESM: index.mjs (23 KB)
  - CJS: index.cjs (23 KB)
  - Types: index.d.mts & index.d.cts (3.8 KB each)
  - CSS: styles.css (1.3 KB)
- ✅ Package tarball tested (38 KB total)
- ✅ Package name "panelgrid" is available on npm

## Next Steps (After Merge)
1. Merge this PR to main
2. Set up npm account and login
3. Publish to npm: `npm publish`
4. Create GitHub release with v0.1.0 tag

## Testing
The package has been verified locally using `yarn pack`. All required files are included and the package structure is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)